### PR TITLE
feat: mount ssh agent in terraform runs

### DIFF
--- a/hooks/plugin-pipeline.yml
+++ b/hooks/plugin-pipeline.yml
@@ -6,6 +6,7 @@ steps:
           image: "hashicorp/terraform"
           entrypoint: "/bin/sh"
           command: ["-c", "terraform init && terraform validate"]
+          mount-ssh-agent: true
           environment:
             - TF_TOKEN_app_terraform_io
     agents:
@@ -18,6 +19,7 @@ steps:
           image: "hashicorp/terraform"
           entrypoint: "/bin/sh"
           command: ["-c", "terraform init && terraform fmt -recursive -check -diff -write=false"]
+          mount-ssh-agent: true
           environment:
             - TF_TOKEN_app_terraform_io
     agents:


### PR DESCRIPTION
Adds support for mounting the ssh agent of the buildkite agent into the terraform container. 

This allows the terraform containers to authenticate and validate the ssh_host keys for private modules included in other terraform modules. 

See https://github.com/buildkite-plugins/docker-buildkite-plugin?tab=readme-ov-file#mount-ssh-agent-optional-boolean-or-string for more details